### PR TITLE
promote offline-jobs to 0.0.11

### DIFF
--- a/packageLists/SLAC_Offline_versions.txt
+++ b/packageLists/SLAC_Offline_versions.txt
@@ -7,7 +7,7 @@ lcatr-modulefiles = 0.3.1
 
 [hj_packages]
 metrology-data-analysis = 0.0.4
-offline-jobs = 0.0.10
+offline-jobs = 0.0.11
 
 [dmstack]
 stack_dir = /nfs/farm/g/lsst/u1/software/redhat6-x86_64-64bit-gcc44/DMstack/Winter2015


### PR DESCRIPTION
This to handle filename changes in the ITL data delivery package.
