### PR TITLE
remove setting of MPLBACKEND in setup.sh script

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -196,7 +196,6 @@ export SITENAME=%(site)s
 export DATACAT_CONFIG=%s
 """ % (os.path.join(datacat_pars['datacatdir']), datacat_pars['datacat_config'])
         python_configs += "export PYTHONPATH=%s\n" % ":".join(python_dirs)
-        python_configs += "export MPLBACKEND=Agg\n"
         return python_configs
 
     def jh(self):


### PR DESCRIPTION
Setting MPLBACKEND prevents the metrology-data-analysis code from using the cairo renderer for matplotlib's 3D plotting.