### PR TITLE
Upgrade to DMstack v13_0 at SLAC

### DIFF
--- a/packageLists/Externals_versions.txt
+++ b/packageLists/Externals_versions.txt
@@ -1,2 +1,2 @@
 [externals]
-python = /nfs/farm/g/lsst/u1/software/redhat6-x86_64-64bit-gcc44/anaconda/2.3.0/bin/python2.7
+python = /nfs/farm/g/lsst/u1/software/redhat6-x86_64-64bit-gcc44/anaconda/4.3.1/bin/python2.7

--- a/packageLists/IR2_JH_versions.txt
+++ b/packageLists/IR2_JH_versions.txt
@@ -19,7 +19,7 @@ jh-dev-tools = 0.0.1
 EO-analysis-jobs = 0.0.7
 
 [dmstack]
-stack_dir = /lsst/dh/software/centos7-gcc48/anaconda/py-2.7/envs/v12_0
+stack_dir = /lsst/dh/software/centos7-gcc48/anaconda/py-2.7-4.3.14/envs/v13_0
 
 [datacat]
 datacatdir = /lsst/dh/software/centos7-gcc48/dev/datacat/0.4

--- a/packageLists/SLAC_Offline_versions.txt
+++ b/packageLists/SLAC_Offline_versions.txt
@@ -13,7 +13,7 @@ eTraveler-clientAPI = 1.2.2
 eotest = 0.0.25
 
 [dmstack]
-stack_dir = /lsst/dh/software/centos7-gcc48/anaconda/py-2.7-4.3.14/envs/v13_0
+stack_dir = /nfs/farm/g/lsst/u1/software/redhat6-x86_64-64bit-gcc44/DMstack/v13_0
 
 [datacat]
 datacatdir = /afs/slac/u/gl/srs/datacat/dev/0.4

--- a/packageLists/SLAC_Offline_versions.txt
+++ b/packageLists/SLAC_Offline_versions.txt
@@ -10,10 +10,10 @@ offline-jobs = 0.0.23
 eTraveler-clientAPI = 1.2.2
 
 [eups_packages]
-eotest = 0.0.21
+eotest = 0.0.25
 
 [dmstack]
-stack_dir = /nfs/farm/g/lsst/u1/software/redhat6-x86_64-64bit-gcc44/DMstack/v12_0
+stack_dir = /lsst/dh/software/centos7-gcc48/anaconda/py-2.7-4.3.14/envs/v13_0
 
 [datacat]
 datacatdir = /afs/slac/u/gl/srs/datacat/dev/0.4


### PR DESCRIPTION
The package lists for SLAC_Offline and IR2 have been updated to point to DMstack v13_0.  SLAC_Offline was also upgraded from eotest 0.0.21 to 0.0.25 to match IR2, since we require at least eotest 0.0.22 for v13_0.  
Tested SLAC_Offline installation via a vendor ingest:
http://lsst-camera.slac.stanford.edu/eTraveler/exp/LSST-CAMERA/displayActivity.jsp?activityId=30610&dataSourceMode=Dev#theFold

It may prove interesting to compare the output to that obtained with the original ingest in Prod.

Also modified the version of python in the Externals package list to use the same version utilized as the base for DMstack v13_0.  It is unclear to me, whether this setting has any real effect.

Open to suggestions for testing on IR2. It is likely the v13_0 installation must be propagated to other IR2 machines (by Stuart?) when this upgrade is accepted.