### PR TITLE
promote eotest to 0.0.29 for IR2_JH and SLAC_Offline; remove sequence…

### DIFF
--- a/packageLists/IR2_JH_versions.txt
+++ b/packageLists/IR2_JH_versions.txt
@@ -1,18 +1,17 @@
 [jh]
 harnessed-jobs = 0.4.66
-lcatr-harness = 0.13.0
+lcatr-harness = 0.15.1
 lcatr-schema = 0.5.2
 lcatr-modulefiles = 0.3.1
 
 [eups_packages]
-eotest = 0.0.28
+eotest = 0.0.29
 
 [packages]
 eTraveler-clientAPI = 1.2.2
 metrology-data-analysis = 0.0.14
 camera-model = 0.0.7
 config_files = 0.0.12
-sequencer-files = 0.1.0
 jh-ccs-utils = 0.0.8
 IandT-jobs = 0.1.4
 jh-dev-tools = 0.0.1

--- a/packageLists/SLAC_Offline_versions.txt
+++ b/packageLists/SLAC_Offline_versions.txt
@@ -10,7 +10,7 @@ offline-jobs = 0.0.25
 eTraveler-clientAPI = 1.2.2
 
 [eups_packages]
-eotest = 0.0.28
+eotest = 0.0.29
 
 [dmstack]
 stack_dir = /nfs/farm/g/lsst/u1/software/redhat6-x86_64-64bit-gcc44/DMstack/v12_0


### PR DESCRIPTION
…r-files from IR2_JH and update lcatr-harness to 0.15.1