### PR TITLE
promote offline-jobs to 0.0.26, eotest to 0.0.30, eTraveler-clientAPI…

### DIFF
--- a/packageLists/SLAC_Offline_versions.txt
+++ b/packageLists/SLAC_Offline_versions.txt
@@ -6,11 +6,11 @@ lcatr-modulefiles = 0.3.1
 
 [packages]
 metrology-data-analysis = 0.0.17
-offline-jobs = 0.0.25
-eTraveler-clientAPI = 1.2.2
+offline-jobs = 0.0.26
+eTraveler-clientAPI = 1.7.1
 
 [eups_packages]
-eotest = 0.0.29
+eotest = 0.0.30
 
 [dmstack]
 stack_dir = /nfs/farm/g/lsst/u1/software/redhat6-x86_64-64bit-gcc44/DMstack/v12_0


### PR DESCRIPTION
… to 1.7.1