### PR TITLE
ETCCB-609

### DIFF
--- a/packageLists/IR2_JH_versions.txt
+++ b/packageLists/IR2_JH_versions.txt
@@ -5,20 +5,20 @@ lcatr-schema = 0.7.0
 lcatr-modulefiles = 0.4.0
 
 [eups_packages]
-eotest = 0.1.5
+eotest = 0.1.7
 
 [packages]
 eTraveler-clientAPI = 1.7.1
 metrology-data-analysis = 0.0.14
-camera-model = 0.1.2
+camera-model = 0.1.3
 config_files = 0.0.12
-jh-ccs-utils = 0.1.5
-IandT-jobs = 0.2.0
+jh-ccs-utils = 0.1.7
+IandT-jobs = 0.2.2
 jh-dev-tools = 0.1.0
-EO-analysis-jobs = 0.1.6
+EO-analysis-jobs = 0.1.8
 
 [dmstack]
-stack_dir = /lsst/dh/software/centos7-gcc48/stack/v17_gcc7
+stack_dir = /gpfs/slac/lsst/fs3/g/software/stack/v18.1.0_gcc7
 
 [datacat]
 datacatdir = /lsst/dh/software/centos7-gcc48/dev/datacat/0.4

--- a/packageLists/IR2_JH_versions.txt
+++ b/packageLists/IR2_JH_versions.txt
@@ -8,6 +8,7 @@ lcatr-modulefiles = 0.4.0
 eotest = 0.1.7
 
 [packages]
+sequencer-files = 0.2.0
 eTraveler-clientAPI = 1.7.1
 metrology-data-analysis = 0.0.14
 camera-model = 0.1.3


### PR DESCRIPTION
Deploy EO-analysis-jobs 0.1.8, eotest 0.1.7, jh-ccs-utils 0.1.7, camera-model 0.1.3, IandT-jobs 0.2.2, sequencer-files 0.2.0 to IR2 JH installation.   Also set up LSST Stack v18.1.0.