### PR TITLE
raise exception if config file is empty/dne

### DIFF
--- a/bin/install.py
+++ b/bin/install.py
@@ -15,7 +15,9 @@ class Parfile(dict):
         super(Parfile, self).__init__()
         parser = configparser.ConfigParser()
         parser.optionxform = str
-        parser.read(infile)
+        result = parser.read(infile)
+        if not result:
+            raise RuntimeError("invalid or empty config file: {f}".format(f=infile))
         for key, value in parser.items(section):
             self[key] = self._cast(value)
     def _cast(self, value):


### PR DESCRIPTION
The current behavior of `install.py` is to exit `0` and without printing a warning if given an invalid config file path.